### PR TITLE
Improve mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,9 @@ layout: null
         flex-direction: column;
         align-items: flex-start;
       }
+      .navbar img.logo {
+        display: none;
+      }
       .mobile-menu-button {
         display: block;
         background: none;


### PR DESCRIPTION
## Summary
- hide the navigation logo on small screens

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489de8f97c832c8c4296db9fcad547