### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/labs/flight-prediction.html
+++ b/labs/flight-prediction.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=yes" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
     <meta https-equiv="refresh" content="content=60" />
     <style type="text/css">
       html { height: 100% } 

--- a/labs/google_maps_files/header.txt
+++ b/labs/google_maps_files/header.txt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=yes" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
     <meta http-equiv="refresh" content="content=60" />
     <style type="text/css">
       html { height: 100% } 

--- a/labs/google_maps_files/maps_ex01.html
+++ b/labs/google_maps_files/maps_ex01.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=yes" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
     <meta http-equiv="refresh" content="content=60" />
     <style type="text/css">
       html { height: 100% } 

--- a/labs/google_maps_files/maps_ex02.html
+++ b/labs/google_maps_files/maps_ex02.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=yes" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
     <meta http-equiv="refresh" content="content=60" />
     <style type="text/css">
       html { height: 100% } 

--- a/labs/google_maps_files/maps_ex03.html
+++ b/labs/google_maps_files/maps_ex03.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=yes" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
     <meta http-equiv="refresh" content="content=60" />
     <style type="text/css">
       html { height: 100% } 

--- a/labs/google_maps_files/mymap.html
+++ b/labs/google_maps_files/mymap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=yes" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
     <meta http-equiv="refresh" content="content=60" />
     <style type="text/css">
       html { height: 100% } 

--- a/old_index.md
+++ b/old_index.md
@@ -54,4 +54,4 @@ Calendar containing office hours and lecture/lab/discussion times.
 
 [Link to course calendar](https://calendar.google.com/calendar/u/0?cid=dW1pY2guZWR1X3FranB0bnZjNGs5MXA0dDQ4dXExOGFoNWNzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
 
-<iframe src="https://calendar.google.com/calendar/embed?src=umich.edu_qkjptnvc4k91p4t48uq18ah5cs%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?src=umich.edu_qkjptnvc4k91p4t48uq18ah5cs%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>

--- a/syllabus.md
+++ b/syllabus.md
@@ -56,7 +56,7 @@ Office hours are a chance to get to know the course staff, to get clarification 
 **For an up-to-date listing of office hours, always refer to the google calendar!**
 [There is a google calendar available here.](https://calendar.google.com/calendar/u/0?cid=dW1pY2guZWR1X3FranB0bnZjNGs5MXA0dDQ4dXExOGFoNWNzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20)
 
-<iframe src="https://calendar.google.com/calendar/embed?src=umich.edu_qkjptnvc4k91p4t48uq18ah5cs%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?src=umich.edu_qkjptnvc4k91p4t48uq18ah5cs%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
 
 ## Canvas & Course Resources
 


### PR DESCRIPTION
## Summary
- set `width=device-width` meta on HTML pages
- make course calendar iframes expand to full width on mobile

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848a027f6c0832c94b72be369944a4c