### PR TITLE
Add staff page with portraits

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,12 +109,19 @@ layout: null
       margin: 25px auto 0;
     }
     .calendar {
-      margin: 40px;
+      margin: 40px auto;
       text-align: center;
     }
     .calendar iframe {
       width: 100%;
       max-width: 100%;
+    }
+    .calendar-section {
+      max-width: 1000px;
+      margin: 40px auto;
+      padding: 0 20px;
+      color: #00274C;
+      text-align: center;
     }
     .about, .links {
       max-width: 1000px;
@@ -188,6 +195,7 @@ layout: null
         </ul>
       </li>
       <li><a href="{{ '/project/project' | relative_url }}">Project</a></li>
+      <li><a href="{{ '/staff' | relative_url }}">Staff</a></li>
       <li class="dropdown"><a href="{{ '/resources' | relative_url }}">Resources</a>
         <ul class="dropdown-content">
           <li><a href="{{ '/tutorials' | relative_url }}">Tutorials</a></li>
@@ -241,9 +249,14 @@ layout: null
       <a class="button-link" href="{{ '/resources' | relative_url }}">Supplemental Resources</a>
     </div>
   </section>
-  <div class="calendar">
-    <iframe class="calendar-iframe" src="https://calendar.google.com/calendar/embed?src=umich.edu_qkjptnvc4k91p4t48uq18ah5cs%40group.calendar.google.com&ctz=America%2FNew_York" style="border:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
-  </div>
+  <section class="calendar-section">
+    <h2>Course Calendar</h2>
+    <p>Stay up to date with lectures, labs, office hours, and due dates.</p>
+    <div class="calendar">
+      <iframe class="calendar-iframe" src="https://calendar.google.com/calendar/embed?src=umich.edu_qkjptnvc4k91p4t48uq18ah5cs%40group.calendar.google.com&ctz=America%2FNew_York" style="border:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+    </div>
+    <p><a href="https://calendar.google.com/calendar/u/0?cid=dW1pY2guZWR1X3FranB0bnZjNGs5MXA0dDQ4dXExOGFoNWNzQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20">Open Calendar in Google</a></p>
+  </section>
   <script>
     window.addEventListener('scroll', function() {
       var navbar = document.querySelector('.navbar');

--- a/staff.md
+++ b/staff.md
@@ -1,0 +1,84 @@
+---
+layout: spec
+latex: true
+---
+
+# Course Staff
+
+Below you can meet the instructors and instructional aides who run ENGR 100-950.
+Each staff member has a placeholder portrait image that can be replaced with a
+photo located in `media/`.
+
+<style>
+.staff-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+.staff-member {
+  text-align: center;
+  padding: 1em;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+.staff-member img {
+  width: 150px;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 50%;
+  background: #f0f0f0;
+  margin-bottom: 10px;
+}
+</style>
+
+<div class="staff-grid">
+  <div class="staff-member">
+    <img src="{{ '/media/ridley.png' | relative_url }}" alt="Prof. Aaron Ridley portrait">
+    <h3>Prof. Aaron Ridley</h3>
+    <p>Technical lead</p>
+    <p><a href="mailto:ridley@umich.edu">ridley@umich.edu</a></p>
+    <p>Office: 1416 CSRB</p>
+  </div>
+  <div class="staff-member">
+    <img src="{{ '/media/alanhogg.png' | relative_url }}" alt="Dr. Alan Hogg portrait">
+    <h3>Dr. Alan Hogg</h3>
+    <p>Communication Instructor - lead</p>
+    <p><a href="mailto:alanhogg@umich.edu">alanhogg@umich.edu</a></p>
+    <p>Office: GFL</p>
+  </div>
+  <div class="staff-member">
+    <img src="{{ '/media/davidgrs.png' | relative_url }}" alt="Dr. David Greenspan portrait">
+    <h3>Dr. David Greenspan</h3>
+    <p>Communication Instructor - lead</p>
+    <p><a href="mailto:davidgrs@umich.edu">davidgrs@umich.edu</a></p>
+    <p>Office: GFL</p>
+  </div>
+  <div class="staff-member">
+    <img src="{{ '/media/hbarnard.png' | relative_url }}" alt="Hannah Barnard portrait">
+    <h3>Hannah Barnard</h3>
+    <p>Instructional Aide</p>
+    <p><a href="mailto:hbarnard@umich.edu">hbarnard@umich.edu</a></p>
+    <p>Office: 1210 CSRB</p>
+  </div>
+  <div class="staff-member">
+    <img src="{{ '/media/zianren.png' | relative_url }}" alt="Zian (Sam) Ren portrait">
+    <h3>Zian (Sam) Ren</h3>
+    <p>Instructional Aide</p>
+    <p><a href="mailto:zianren@umich.edu">zianren@umich.edu</a></p>
+    <p>Office: 1210 CSRB</p>
+  </div>
+  <div class="staff-member">
+    <img src="{{ '/media/jfwoods.png' | relative_url }}" alt="Jack Woods portrait">
+    <h3>Jack Woods</h3>
+    <p>Instructional Aide</p>
+    <p><a href="mailto:jfwoods@umich.edu">jfwoods@umich.edu</a></p>
+    <p>Office: 1210 CSRB</p>
+  </div>
+  <div class="staff-member">
+    <img src="{{ '/media/benjamen.png' | relative_url }}" alt="Ben Miller portrait">
+    <h3>Ben Miller</h3>
+    <p>Instructional Aide</p>
+    <p><a href="mailto:benjamen@umich.edu">benjamen@umich.edu</a></p>
+    <p>Office: 1210 CSRB</p>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- split out staff page into individual sections with image placeholders
- keep Staff link in navigation
- keep Course Calendar heading and text

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3c4d7fc832c92e3a8ef2037a50e