### PR TITLE
Improve navbar links

### DIFF
--- a/facilities.html
+++ b/facilities.html
@@ -55,6 +55,7 @@ toc: false
       text-decoration: none;
       font-weight: bold;
     }
+    .home-link { display: none; }
     .navbar li:hover > a { background-color: #001d38; }
     .dropdown-content {
       display: none;
@@ -133,6 +134,9 @@ toc: false
       .navbar a {
         padding: 10px;
       }
+      .home-link {
+        display: block;
+      }
       .dropdown-content {
         display: none;
       }
@@ -141,7 +145,9 @@ toc: false
 </head>
 <body>
   <nav class="navbar">
-    <img class="logo" src="{{ '/media/umich-coe3.png' | relative_url }}" alt="University of Michigan, College of Engineering">
+    <a class="logo-link" href="{{ '/' | relative_url }}">
+      <img class="logo" src="{{ '/media/umich-coe3.png' | relative_url }}" alt="University of Michigan, College of Engineering">
+    </a>
     <ul class="nav-links">
       <li class="dropdown"><a href="{{ '/syllabus' | relative_url }}">Syllabus</a>
         <ul class="dropdown-content">
@@ -156,7 +162,7 @@ toc: false
       </li>
       <li><a href="{{ '/project/project' | relative_url }}">Project</a></li>
       <li><a href="{{ '/staff' | relative_url }}">Staff</a></li>
-      <li><a href="{{ '/facilities' | relative_url }}">Facilities</a></li>
+      <li class="home-link"><a href="{{ '/' | relative_url }}">Home</a></li>
     </ul>
   </nav>
   <div class="hero">

--- a/index.html
+++ b/index.html
@@ -184,7 +184,9 @@ toc: false
 </head>
 <body>
   <nav class="navbar">
-    <img class="logo" src="{{ '/media/umich-coe3.png' | relative_url }}" alt="University of Michigan, College of Engineering">
+    <a class="logo-link" href="{{ '/' | relative_url }}">
+      <img class="logo" src="{{ '/media/umich-coe3.png' | relative_url }}" alt="University of Michigan, College of Engineering">
+    </a>
     <ul class="nav-links">
       <li class="dropdown"><a href="{{ '/syllabus' | relative_url }}">Syllabus</a>
         <ul class="dropdown-content">

--- a/staff.html
+++ b/staff.html
@@ -55,6 +55,7 @@ toc: false
       text-decoration: none;
       font-weight: bold;
     }
+    .home-link { display: none; }
     .navbar li:hover > a { background-color: #001d38; }
     .dropdown-content {
       display: none;
@@ -133,6 +134,9 @@ toc: false
       .navbar a {
         padding: 10px;
       }
+      .home-link {
+        display: block;
+      }
       .dropdown-content {
         display: none;
       }
@@ -141,7 +145,9 @@ toc: false
 </head>
 <body>
   <nav class="navbar">
-    <img class="logo" src="{{ '/media/umich-coe3.png' | relative_url }}" alt="University of Michigan, College of Engineering">
+    <a class="logo-link" href="{{ '/' | relative_url }}">
+      <img class="logo" src="{{ '/media/umich-coe3.png' | relative_url }}" alt="University of Michigan, College of Engineering">
+    </a>
     <ul class="nav-links">
       <li class="dropdown"><a href="{{ '/syllabus' | relative_url }}">Syllabus</a>
         <ul class="dropdown-content">
@@ -155,8 +161,8 @@ toc: false
         </ul>
       </li>
       <li><a href="{{ '/project/project' | relative_url }}">Project</a></li>
-      <li><a href="{{ '/staff' | relative_url }}">Staff</a></li>
       <li><a href="{{ '/facilities' | relative_url }}">Facilities</a></li>
+      <li class="home-link"><a href="{{ '/' | relative_url }}">Home</a></li>
     </ul>
   </nav>
   <div class="hero">


### PR DESCRIPTION
## Summary
- clicking the logo now navigates to the landing page
- show a Home link in the mobile navbar
- remove Staff and Facilities links on their own pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849c11e9f7c832c854a71b7939a1c88